### PR TITLE
Ensure KritaToot tries to sent png, jpeg or gif to mastodon.

### DIFF
--- a/kritatoot/TempMedia.py
+++ b/kritatoot/TempMedia.py
@@ -2,6 +2,7 @@
 import os
 import inspect
 from tempfile import gettempdir
+import re
 
 
 from krita import *
@@ -30,10 +31,21 @@ def saveTempMedia():
         if not docname:
             docname = 'noname.png'
         
+        # Check if the file in question is one that can be uploaded to mastodon
+
+        match = re.search(r"\w+\.png|jpeg|gif|jpg", docname)
+
+        # If not, save as a png.
+        if match is None:
+            docname = re.sub(r"(\.\w+)", ".png", docname, flags=re.IGNORECASE)
+
         tempbase = os.path.basename(docname)
         pathname = os.path.join(tempdir, tempbase)
         
+        batchmode = doc.batchmode()
+        doc.setBatchmode(True)
         doc.exportImage(pathname, InfoObject())
+        doc.setBatchmode(batchmode)
         
         print('export current doc as %s' % pathname)
         


### PR DESCRIPTION
This'll help with posting files that are saved to *.kra or otherwise.

This doesn't always seem to work 100%? There seems to be a timing issue, but my debug messages aren't working properly on this device, so I'll need to fix that first before I can double check if that.

I also enabled batchmode, which means that Krita will use a default setting for png, but it'll help people who lose track of the export window.

I also need to doublecheck if non-sRGB/Grayscale files are converted properly, because that might be another big papercut.